### PR TITLE
Add data-request-files attribute to form_ajax

### DIFF
--- a/components/filepondform/default.htm
+++ b/components/filepondform/default.htm
@@ -6,7 +6,7 @@
     </div>
 {% endif %}
 
-{{ form_ajax(__SELF__ ~ '::onFormSubmit', { id: __SELF__ }) }}
+{{ form_ajax(__SELF__ ~ '::onFormSubmit', { id: __SELF__, 'data-request-files': 'true' }) }}
 
     <div id="{{ __SELF__ }}_forms_flash"></div>
 


### PR DESCRIPTION
This pull request makes a minor update to the file upload form component to ensure that file uploads are handled correctly by AJAX requests.

* File upload handling: The `form_ajax` call in `components/filepondform/default.htm` was updated to include the `'data-request-files': 'true'` option, which explicitly enables file uploads via AJAX for improved security and functionality.