### PR TITLE
refactor(filepond): update global_allowed_filesize default and validation

### DIFF
--- a/classes/filepond/FilePondController.php
+++ b/classes/filepond/FilePondController.php
@@ -130,7 +130,7 @@ class FilePondController extends BaseController
      */
     private function checkInvalidSize() : bool
     {
-        $max_size = Settings::get('global_allowed_filesize', 10000);
+        $max_size = Settings::get('global_allowed_filesize');
 
         $field = $this->getUploadFieldName();
 

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -13,9 +13,26 @@ class Settings extends Model
 
     public $rules = [
         'gdpr_days' => 'required|numeric',
+        'global_allowed_filesize' => 'required|integer|min:0',
     ];
 
     public $attributeNames = [
         'gdpr_days' => 'GDPR',
     ];
+
+    public function initSettingsData()
+    {
+        $kb = fn($value) => match (strtolower(substr(trim($value), -1))) {
+            'g' => (float)$value * 1048576,  // 1024^2
+            'm' => (float)$value * 1024,     // 1024^1
+            'k' => (float)$value,
+            default => (float)$value / 1024
+        };
+
+        $this->global_allowed_filesize = round(min(
+            $kb(ini_get('upload_max_filesize')),
+            $kb(ini_get('post_max_size'))
+        ));
+    }
+
 }

--- a/models/settings/fields.yaml
+++ b/models/settings/fields.yaml
@@ -29,9 +29,9 @@ tabs:
     global_allowed_filesize:
       label: Max upload size (in kilobytes)
       type: number
-      default: 10000
       tab: josephcrowell.magicforms::lang.settings.tabs.general
       span: left
+      min: 0
 
     global_allowed_files:
       label: Allowed file formats


### PR DESCRIPTION
- Remove hardcoded default for `global_allowed_filesize`.
- Set default based on PHP's `upload_max_filesize` and `post_max_size`.
- Validate as a non-negative integer in Settings.
